### PR TITLE
Change type of szError to reflect actual usage

### DIFF
--- a/Cpipe.hpp
+++ b/Cpipe.hpp
@@ -30,7 +30,7 @@ class CPipe {
 		CHAR	*cBuffer;
 		DWORD	dBufferSize;
 		int		iError;
-		LPSTR	szError[ERROR_TEXT_SIZE];
+		CHAR	szError[ERROR_TEXT_SIZE];
 
 
 	private:


### PR DESCRIPTION
In the CPipe class, szError is defined as an array of strings
(LPSTR szError[ERROR_TEXT_SIZE]) but is used everywhere as a string
of length ERROR_TEXT_SIZE, being explicitly cast to char * in a
number of places.  Newer MinGW GCC versions catch this when an
attempt is made to null terminate the string (array of strings)
with a '\0' character which is a char, not a char * and quite
rightly call out the illegal implied cast.

Change szError to be of type CHAR[] to reflect the actual usage.